### PR TITLE
Add preloaded runtime artifact for app-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,12 @@ jobs:
           name: ${{ steps.release_version.outputs.artifact_base }}-runtime
           path: artifacts/${{ steps.release_version.outputs.artifact_base }}-runtime
 
+      - name: Upload staged preloaded artifact folder
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ steps.release_version.outputs.artifact_base }}-preloaded
+          path: artifacts/${{ steps.release_version.outputs.artifact_base }}-preloaded
+
       - name: Upload packaged source archive
         uses: actions/upload-artifact@v6
         with:
@@ -65,6 +71,12 @@ jobs:
         with:
           name: ${{ steps.release_version.outputs.artifact_base }}-runtime-archive
           path: artifacts/${{ steps.release_version.outputs.artifact_base }}-runtime.tar.gz
+
+      - name: Upload packaged preloaded archive
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ steps.release_version.outputs.artifact_base }}-preloaded-archive
+          path: artifacts/${{ steps.release_version.outputs.artifact_base }}-preloaded.tar.gz
 
       - name: Create or update GitHub release
         env:
@@ -78,5 +90,6 @@ jobs:
           fi
           SOURCE_ARCHIVE="artifacts/${{ steps.release_version.outputs.artifact_base }}-source.tar.gz"
           RUNTIME_ARCHIVE="artifacts/${{ steps.release_version.outputs.artifact_base }}-runtime.tar.gz"
-          gh release view "$TAG_NAME" >/dev/null 2>&1 || gh release create "$TAG_NAME" --title "$TAG_NAME" --notes "Source and bootstrap-download runtime artifacts."
-          gh release upload "$TAG_NAME" "$SOURCE_ARCHIVE" "$RUNTIME_ARCHIVE" --clobber
+          PRELOADED_ARCHIVE="artifacts/${{ steps.release_version.outputs.artifact_base }}-preloaded.tar.gz"
+          gh release view "$TAG_NAME" >/dev/null 2>&1 || gh release create "$TAG_NAME" --title "$TAG_NAME" --notes "Source, bootstrap-download, and preloaded runtime artifacts."
+          gh release upload "$TAG_NAME" "$SOURCE_ARCHIVE" "$RUNTIME_ARCHIVE" "$PRELOADED_ARCHIVE" --clobber

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Current local URLs:
 
 ## Current release artifact
 
-This starter repo now has bounded source and runnable bootstrap-download release artifacts.
+This starter repo now has bounded source, bootstrap-download, and preloaded/no-download release artifacts.
 
 Current local commands:
 - `npm test`
@@ -52,7 +52,7 @@ Current shipped artifact contents are documented in:
 - `docs/release-artifact.md`
 
 Current honest label:
-- this repo ships a runnable plain-Node app-host starter plus explicit source and bootstrap-download runtime bundles
+- this repo ships a runnable plain-Node app-host starter plus explicit source, bootstrap-download, and preloaded runtime bundles
 
 ## Minimal POC
 

--- a/docs/release-artifact.md
+++ b/docs/release-artifact.md
@@ -1,10 +1,11 @@
 # Release artifacts
 
-This repo now ships two bounded release artifacts.
+This repo now ships three bounded release artifacts.
 
 Each artifact has a different job:
 - source template
 - runnable bootstrap-download bundle
+- runnable preloaded bundle
 
 ## Source template
 
@@ -64,6 +65,30 @@ How it works:
 Honest label:
 - **runnable bootstrap-download bundle**
 
+## Runnable preloaded bundle
+
+Artifact:
+- `service-lasso-app-node-<version>-preloaded.tar.gz`
+
+Purpose:
+- provide a ready-to-run plain-Node host with the core runtime already installed
+- include bundled Service Admin assets for the host shell
+- keep the canonical repo-owned `services/` inventory inside the artifact
+- prove that the Echo Service archive is already present before first install/use
+
+What ships:
+- everything in the runnable bootstrap-download bundle
+- preseeded Echo Service archive under:
+  - `.workspace/services/echo-service/.state/artifacts/<releaseTag>/<assetName>`
+
+How it works:
+- the app repo still owns the same canonical `services/echo-service/service.json`
+- the preloaded artifact seeds the matching archive into the runtime-owned service state before first use
+- on `install`, Service Lasso reuses that archive and skips the network fetch
+
+Honest label:
+- **runnable preloaded bundle**
+
 ## What the release proves
 
 The release now proves:
@@ -72,6 +97,7 @@ The release now proves:
 - the runnable artifact can boot Service Lasso and Service Admin without sibling-repo checkout tricks
 - Echo Service acquisition now depends on manifest-owned archive metadata instead of a generated local wrapper
 - bootstrap-download mode installs the service payload before first use
+- preloaded mode installs from an already-shipped archive without a first-run download
 
 ## Private package note
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "start": "node src/index.js",
-    "test": "node --test tests/**/*.test.js",
+    "test": "node --test --test-concurrency=1 tests/**/*.test.js",
     "release:artifact": "node scripts/release-artifact.mjs",
     "release:verify": "node scripts/release-verify.mjs"
   },

--- a/scripts/release-artifact-lib.mjs
+++ b/scripts/release-artifact-lib.mjs
@@ -151,6 +151,7 @@ async function getLocalCorePackageArchive(repoRoot) {
     const version = corePackageJson.version;
     const artifactRoot = path.join(coreRepoRoot, "artifacts", "npm", `service-lasso-package-${version}`);
     const archivePath = path.join(artifactRoot, `service-lasso-service-lasso-${version}.tgz`);
+    await rm(artifactRoot, { recursive: true, force: true });
     await runNpmCommand(["run", "package:stage"], {
       cwd: coreRepoRoot,
       env: process.env,
@@ -220,6 +221,7 @@ async function stageSingleArtifact({
   notes,
   installDependencies = false,
   adminDistRoot = null,
+  preloadedArchive = null,
 }) {
   const artifactRoot = path.join(outputRoot, artifactName);
   await rm(artifactRoot, { recursive: true, force: true });
@@ -237,6 +239,22 @@ async function stageSingleArtifact({
     const payloadAdminRoot = path.join(artifactRoot, ".payload", "admin");
     await mkdir(path.dirname(payloadAdminRoot), { recursive: true });
     await cp(adminDistRoot, payloadAdminRoot, { recursive: true });
+  }
+
+  if (preloadedArchive) {
+    const { releaseTag, assetName, archivePath } = preloadedArchive;
+    const targetPath = path.join(
+      artifactRoot,
+      ".workspace",
+      "services",
+      "echo-service",
+      ".state",
+      "artifacts",
+      releaseTag,
+      assetName,
+    );
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await cp(archivePath, targetPath, { force: true });
   }
 
   const manifest = await writeReleaseManifest({
@@ -341,7 +359,7 @@ async function createVerificationAdminDist(rootDir) {
   return adminDistRoot;
 }
 
-async function createVerificationReleaseFixture(rootDir) {
+async function createVerificationReleaseFixture(rootDir, assetNameOverride = null) {
   const fixtureRoot = path.join(rootDir, ".verify-fixture");
   const workRoot = path.join(fixtureRoot, "work");
   const archiveRoot = path.join(fixtureRoot, "archives");
@@ -352,7 +370,7 @@ async function createVerificationReleaseFixture(rootDir) {
   let assetName;
   let archiveType;
   if (process.platform === "win32") {
-    assetName = "echo-service-win32.zip";
+    assetName = assetNameOverride ?? "echo-service-win32.zip";
     archiveType = "zip";
     const powershell =
       process.env.SystemRoot
@@ -365,7 +383,7 @@ async function createVerificationReleaseFixture(rootDir) {
       `Compress-Archive -Path '${path.join(workRoot, "*").replace(/'/g, "''")}' -DestinationPath '${path.join(archiveRoot, assetName).replace(/'/g, "''")}' -Force`,
     ]);
   } else {
-    assetName = process.platform === "darwin" ? "echo-service-darwin.tar.gz" : "echo-service-linux.tar.gz";
+    assetName = assetNameOverride ?? (process.platform === "darwin" ? "echo-service-darwin.tar.gz" : "echo-service-linux.tar.gz");
     archiveType = "tar.gz";
     await runCommand("tar", ["-czf", path.join(archiveRoot, assetName), "-C", workRoot, "."]);
   }
@@ -373,6 +391,7 @@ async function createVerificationReleaseFixture(rootDir) {
   const archivePath = path.join(archiveRoot, assetName);
   return {
     fixtureRoot,
+    releaseTag: "fixture",
     assetName,
     archiveType,
     archivePath,
@@ -600,6 +619,65 @@ async function verifyRuntimeArtifact({ artifactRoot, archivePath }) {
   }
 }
 
+async function verifyPreloadedArtifact({ artifactRoot, archivePath }) {
+  await stat(archivePath);
+  await stat(path.join(artifactRoot, "release-artifact.json"));
+  await stat(path.join(artifactRoot, "node_modules"));
+  await stat(path.join(artifactRoot, ".payload", "admin", "index.html"));
+
+  const fixture = await createVerificationReleaseFixture(artifactRoot);
+  const archiveServer = await startArchiveServer(fixture);
+  const sourceServicesRoot = await createVerificationSourceServicesRoot(artifactRoot, archiveServer, fixture);
+  const preloadedArchivePath = path.join(
+    artifactRoot,
+    ".workspace",
+    "services",
+    "echo-service",
+    ".state",
+    "artifacts",
+    "fixture",
+    fixture.assetName,
+  );
+  await mkdir(path.dirname(preloadedArchivePath), { recursive: true });
+  await cp(fixture.archivePath, preloadedArchivePath, { force: true });
+
+  const hostPort = await reserveLoopbackPort();
+  const runtimePort = await reserveLoopbackPort();
+  const smoke = await smokeStarterHost(artifactRoot, {
+    ...process.env,
+    SERVICE_LASSO_APP_NODE_HOST_PORT: hostPort,
+    SERVICE_LASSO_API_PORT: runtimePort,
+    SERVICE_LASSO_APP_NODE_SOURCE_SERVICES_ROOT: sourceServicesRoot,
+    SERVICE_LASSO_WORKSPACE_ROOT: path.join(artifactRoot, ".workspace", "runtime"),
+  });
+
+  try {
+    const runtimeUrl = `http://127.0.0.1:${runtimePort}`;
+    const install = await postJson(`${runtimeUrl}/api/services/echo-service/install`);
+
+    if (install.status !== 200) {
+      throw new Error(`Install action failed: ${JSON.stringify(install, null, 2)}`);
+    }
+
+    if (archiveServer.getRequestCount() !== 0) {
+      throw new Error("Preloaded runtime artifact should not fetch the service archive during install.");
+    }
+
+    const serviceDetail = await waitForJson(`${runtimeUrl}/api/services/echo-service`);
+    return {
+      hostStatus: smoke.hostStatus,
+      runtimeHealth: smoke.runtimeHealth,
+      archiveDownloads: archiveServer.getRequestCount(),
+      installStatus: install.status,
+      lifecycleState: serviceDetail.lifecycleState ?? null,
+    };
+  } finally {
+    await shutdownSmokedHost(smoke, "SIGINT");
+    await archiveServer.close();
+    await rm(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+}
+
 export async function stageReleaseArtifacts({ repoRoot, outputRoot = path.join(repoRoot, "artifacts"), version, sourceAdminDistRoot } = {}) {
   const resolvedVersion = version ?? (await getReleaseVersion(repoRoot));
   const baseName = await getArtifactNameBase(repoRoot, resolvedVersion);
@@ -640,12 +718,37 @@ export async function stageReleaseArtifacts({ repoRoot, outputRoot = path.join(r
     adminDistRoot: resolvedAdminDistRoot,
   });
 
+  const echoManifest = JSON.parse(await readFile(path.join(repoRoot, "services", "echo-service", "service.json"), "utf8"));
+  const echoPlatform = echoManifest.artifact?.platforms?.[process.platform] ?? echoManifest.artifact?.platforms?.default;
+  const preloadedFixture = await createVerificationReleaseFixture(outputRoot, echoPlatform?.assetName ?? null);
+  const preloaded = await stageSingleArtifact({
+    repoRoot,
+    outputRoot,
+    artifactName: `${baseName}-preloaded`,
+    version: resolvedVersion,
+    artifactKind: "runnable-preloaded",
+    relativePaths: runtimeFiles,
+    notes: [
+      "This artifact is ready to run with installed dependencies, bundled Service Admin assets, and a preseeded Echo Service archive.",
+      "It keeps the canonical services/ inventory and proves no first-run service download is required.",
+    ],
+    installDependencies: true,
+    adminDistRoot: resolvedAdminDistRoot,
+    preloadedArchive: {
+      releaseTag: echoManifest.artifact?.source?.tag ?? preloadedFixture.releaseTag,
+      assetName: preloadedFixture.assetName,
+      archivePath: preloadedFixture.archivePath,
+    },
+  });
+  await rm(preloadedFixture.fixtureRoot, { recursive: true, force: true });
+
   return {
     version: resolvedVersion,
     baseName,
     artifacts: {
       source,
       runtime,
+      preloaded,
     },
   };
 }
@@ -661,6 +764,10 @@ export async function verifyStagedArtifacts({ repoRoot, staged } = {}) {
     artifactRoot: release.artifacts.runtime.artifactRoot,
     archivePath: release.artifacts.runtime.archivePath,
   });
+  const preloadedVerified = await verifyPreloadedArtifact({
+    artifactRoot: release.artifacts.preloaded.artifactRoot,
+    archivePath: release.artifacts.preloaded.archivePath,
+  });
 
   return {
     baseName: release.baseName,
@@ -672,6 +779,10 @@ export async function verifyStagedArtifacts({ repoRoot, staged } = {}) {
       runtime: {
         ...release.artifacts.runtime,
         verification: runtimeVerified,
+      },
+      preloaded: {
+        ...release.artifacts.preloaded,
+        verification: preloadedVerified,
       },
     },
   };

--- a/scripts/release-artifact.mjs
+++ b/scripts/release-artifact.mjs
@@ -12,3 +12,6 @@ console.log(`- source archive: ${result.artifacts.source.archivePath}`);
 console.log(`- runtime artifact: ${result.artifacts.runtime.artifactName}`);
 console.log(`- runtime folder: ${result.artifacts.runtime.artifactRoot}`);
 console.log(`- runtime archive: ${result.artifacts.runtime.archivePath}`);
+console.log(`- preloaded artifact: ${result.artifacts.preloaded.artifactName}`);
+console.log(`- preloaded folder: ${result.artifacts.preloaded.artifactRoot}`);
+console.log(`- preloaded archive: ${result.artifacts.preloaded.archivePath}`);

--- a/scripts/release-verify.mjs
+++ b/scripts/release-verify.mjs
@@ -14,3 +14,5 @@ console.log(`- source artifact: ${verified.artifacts.source.artifactName}`);
 console.log(`- source archive: ${verified.artifacts.source.archivePath}`);
 console.log(`- runtime artifact: ${verified.artifacts.runtime.artifactName}`);
 console.log(`- runtime archive: ${verified.artifacts.runtime.archivePath}`);
+console.log(`- preloaded artifact: ${verified.artifacts.preloaded.artifactName}`);
+console.log(`- preloaded archive: ${verified.artifacts.preloaded.archivePath}`);

--- a/tests/release-artifact.test.js
+++ b/tests/release-artifact.test.js
@@ -26,6 +26,7 @@ test("starter release artifacts can be staged and verified", async () => {
     assert.match(staged.baseName, new RegExp(`^${packageSuffix}-\\d+\\.\\d+\\.\\d+$`));
     assert.equal(staged.artifacts.source.manifest.artifactKind, "starter-template-source");
     assert.equal(staged.artifacts.runtime.manifest.artifactKind, "runnable-bootstrap-download");
+    assert.equal(staged.artifacts.preloaded.manifest.artifactKind, "runnable-preloaded");
 
     const verified = await verifyStagedArtifacts({
       repoRoot,
@@ -34,6 +35,7 @@ test("starter release artifacts can be staged and verified", async () => {
 
     assert.equal(verified.baseName, staged.baseName);
     assert.ok(verified.artifacts.runtime.verification.archiveDownloads >= 1);
+    assert.equal(verified.artifacts.preloaded.verification.archiveDownloads, 0);
   } finally {
     await rm(outputRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add a runnable preloaded no-download artifact alongside the source and bootstrap-download artifacts
- seed the matching Echo archive into runtime-owned service state before first install
- make the release docs and workflow honest about the three artifact modes

## Testing
- npm test
- npm run release:verify