### PR TITLE
ISS-091 align baseline service inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Current implementation:
 - published `@service-lasso/service-lasso` runtime package consumption
 - host-owned shell at `/`
 - mounted sibling `lasso-@serviceadmin` build at `/admin/`
-- tracked repo-owned `services/` definitions for Echo Service and Service Admin
+- tracked repo-owned baseline `services/` definitions for Echo Service, Service Admin, `@node`, and `@traefik`
 - manifest-owned Echo Service archive metadata under `services/echo-service/service.json`
+- manifest-owned Traefik archive metadata under `services/@traefik/service.json`
 - prepared local `servicesRoot` copied from the tracked service inventory before runtime startup
 
 Current local start command:

--- a/docs/release-artifact.md
+++ b/docs/release-artifact.md
@@ -57,8 +57,8 @@ What ships:
 - generated `release-artifact.json`
 
 How it works:
-- the app repo owns `services/echo-service/service.json`
-- that manifest carries the bounded `artifact` block pointing at the Echo Service release assets
+- the app repo owns the baseline `services/` inventory, including `echo-service`, `service-admin`, `@node`, and `@traefik`
+- release-backed manifests carry bounded `artifact` blocks pointing at their service release assets
 - on `install`, Service Lasso downloads and unpacks the matching archive from the manifest metadata
 - the app artifact itself does not ship the Echo Service archive
 
@@ -82,7 +82,7 @@ What ships:
   - `services/echo-service/.state/artifacts/<releaseTag>/<assetName>`
 
 How it works:
-- the app repo still owns the same canonical `services/echo-service/service.json`
+- the app repo still owns the same canonical baseline `services/` inventory
 - the release package step acquires the matching archive into the repo-owned service folder before publishing
 - on `install`, Service Lasso reuses that archive and skips the network fetch
 

--- a/services/@node/service.json
+++ b/services/@node/service.json
@@ -1,0 +1,19 @@
+{
+  "id": "@node",
+  "name": "Node Runtime",
+  "description": "Local/no-download Node runtime provider used by Service Lasso managed services.",
+  "version": "0.1.0",
+  "enabled": true,
+  "executable": "node",
+  "args": ["--version"],
+  "env": {
+    "NODE_ENV": "development"
+  },
+  "urls": [
+    {
+      "label": "docs",
+      "url": "https://nodejs.org",
+      "kind": "external"
+    }
+  ]
+}

--- a/services/@traefik/service.json
+++ b/services/@traefik/service.json
@@ -1,0 +1,73 @@
+{
+  "id": "@traefik",
+  "name": "Traefik Router",
+  "description": "Release-backed Traefik edge/router service for Service Lasso baseline routing.",
+  "version": "2026.4.25-5301df9",
+  "enabled": true,
+  "ports": {
+    "web": 19080,
+    "admin": 19081
+  },
+  "urls": [
+    {
+      "label": "dashboard",
+      "url": "http://127.0.0.1:${ADMIN_PORT}/dashboard/",
+      "kind": "local"
+    },
+    {
+      "label": "ping",
+      "url": "http://127.0.0.1:${ADMIN_PORT}/ping",
+      "kind": "local"
+    }
+  ],
+  "artifact": {
+    "kind": "archive",
+    "source": {
+      "type": "github-release",
+      "repo": "service-lasso/lasso-traefik",
+      "tag": "2026.4.25-5301df9"
+    },
+    "platforms": {
+      "win32": {
+        "assetName": "lasso-traefik-win32.zip",
+        "assetUrl": "https://github.com/service-lasso/lasso-traefik/releases/download/2026.4.25-5301df9/lasso-traefik-win32.zip",
+        "archiveType": "zip",
+        "command": ".\\traefik.exe",
+        "args": ["--configFile=runtime/traefik.yml"]
+      },
+      "linux": {
+        "assetName": "lasso-traefik-linux.tar.gz",
+        "assetUrl": "https://github.com/service-lasso/lasso-traefik/releases/download/2026.4.25-5301df9/lasso-traefik-linux.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "./traefik",
+        "args": ["--configFile=runtime/traefik.yml"]
+      },
+      "darwin": {
+        "assetName": "lasso-traefik-darwin.tar.gz",
+        "assetUrl": "https://github.com/service-lasso/lasso-traefik/releases/download/2026.4.25-5301df9/lasso-traefik-darwin.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "./traefik",
+        "args": ["--configFile=runtime/traefik.yml"]
+      }
+    }
+  },
+  "install": {
+    "files": [
+      {
+        "path": "./runtime/dynamic.yml",
+        "content": "http:\n  routers: {}\n  services: {}\n"
+      }
+    ]
+  },
+  "config": {
+    "files": [
+      {
+        "path": "./runtime/traefik.yml",
+        "content": "entryPoints:\n  web:\n    address: \"127.0.0.1:${WEB_PORT}\"\n  traefik:\n    address: \"127.0.0.1:${ADMIN_PORT}\"\napi:\n  dashboard: true\nping:\n  entryPoint: traefik\nproviders:\n  file:\n    filename: \"./runtime/dynamic.yml\"\n    watch: true\nlog:\n  level: INFO\n"
+      }
+    ]
+  },
+  "healthcheck": {
+    "type": "process"
+  }
+}


### PR DESCRIPTION
Adds tracked @node and release-backed @traefik service manifests so the app-node template matches the documented baseline inventory.\n\nValidation: npm test; npm run release:verify.