### PR TITLE
docs: add optional provider inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Current implementation:
 - published `@service-lasso/service-lasso` runtime package consumption
 - host-owned shell at `/`
 - mounted sibling `lasso-@serviceadmin` build at `/admin/`
-- tracked repo-owned baseline `services/` definitions for Echo Service, Service Admin, `@node`, `@localcert`, `@nginx`, and `@traefik`
+- tracked repo-owned baseline `services/` definitions for Echo Service, Service Admin, `@node`, `@localcert`, `@nginx`, and `@traefik`, plus disabled optional `@python` and `@java` provider examples
 - manifest-owned Echo Service archive metadata under `services/echo-service/service.json`
 - manifest-owned Traefik archive metadata under `services/@traefik/service.json`, with `@localcert` and `@nginx` declared as Traefik dependencies
-- core Service Lasso services use the `@` prefix: `@node`, `@localcert`, `@nginx`, `@traefik`, and `@serviceadmin`; `echo-service` stays unprefixed because it is the sample/test managed service
+- core Service Lasso services use the `@` prefix: `@node`, `@python`, `@java`, `@localcert`, `@nginx`, `@traefik`, and `@serviceadmin`; `echo-service` stays unprefixed because it is the sample/test managed service
 - prepared local `servicesRoot` copied from the tracked service inventory before runtime startup
 
 Current local start command:

--- a/services/@java/service.json
+++ b/services/@java/service.json
@@ -1,0 +1,58 @@
+{
+  "id": "@java",
+  "name": "Java Runtime",
+  "description": "Release-backed Eclipse Temurin JRE provider for Service Lasso services.",
+  "version": "17.0.18+8",
+  "role": "provider",
+  "enabled": false,
+  "executable": "java",
+  "args": [
+    "--version"
+  ],
+  "env": {},
+  "globalenv": {
+    "JAVA": "${SERVICE_ARTIFACT_COMMAND}",
+    "JAVA_HOME": "${SERVICE_ARTIFACT_ROOT}"
+  },
+  "urls": [
+    {
+      "label": "temurin",
+      "url": "https://adoptium.net/temurin/",
+      "kind": "external"
+    }
+  ],
+  "artifact": {
+    "kind": "archive",
+    "source": {
+      "type": "github-release",
+      "repo": "service-lasso/lasso-java",
+      "tag": "2026.4.27-b313cb0"
+    },
+    "platforms": {
+      "win32": {
+        "assetName": "lasso-java-17.0.18+8-win32.zip",
+        "archiveType": "zip",
+        "command": ".\\bin\\java.exe",
+        "args": [
+          "--version"
+        ]
+      },
+      "linux": {
+        "assetName": "lasso-java-17.0.18+8-linux.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "./bin/java",
+        "args": [
+          "--version"
+        ]
+      },
+      "darwin": {
+        "assetName": "lasso-java-17.0.18+8-darwin.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "./bin/java",
+        "args": [
+          "--version"
+        ]
+      }
+    }
+  }
+}

--- a/services/@python/service.json
+++ b/services/@python/service.json
@@ -1,0 +1,41 @@
+{
+  "id": "@python",
+  "name": "Python Runtime",
+  "description": "Release-backed Python runtime provider for Service Lasso services.",
+  "version": "3.11.5",
+  "role": "provider",
+  "enabled": false,
+  "executable": "python",
+  "args": ["--version"],
+  "env": {
+    "PYTHONUTF8": "1"
+  },
+  "globalenv": {
+    "PYTHON": "${SERVICE_ARTIFACT_COMMAND}",
+    "PYTHON_HOME": "${SERVICE_ARTIFACT_ROOT}",
+    "PYTHONPATH": "${SERVICE_ARTIFACT_ROOT}"
+  },
+  "urls": [
+    {
+      "label": "docs",
+      "url": "https://docs.python.org/3/",
+      "kind": "external"
+    }
+  ],
+  "artifact": {
+    "kind": "archive",
+    "source": {
+      "type": "github-release",
+      "repo": "service-lasso/lasso-python",
+      "tag": "2026.4.27-63f915c"
+    },
+    "platforms": {
+      "win32": {
+        "assetName": "lasso-python-3.11.5-win32.zip",
+        "archiveType": "zip",
+        "command": ".\\python.exe",
+        "args": ["--version"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- adds disabled optional @python and @java provider manifests from service-lasso core
- documents that these are optional provider examples, not baseline startup services
- keeps baseline inventory unchanged while closing service-lasso/service-lasso#172 propagation gap

## Verification
- service.json inventory parse passed
- repo tests passed locally
- git diff --check passed